### PR TITLE
feature/no-more-using-traps

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -5,7 +5,6 @@ const router = express.Router();
 import {Page} from './controllers/_base.js';
 import StartController from './controllers/start.js';
 import GdprController from './controllers/gdpr.js';
-import UsingTrapsController from './controllers/using-traps.js';
 import ComplyController from './controllers/comply.js';
 import ConvictionController from './controllers/conviction.js';
 import EligibleController from './controllers/eligible.js';


### PR DESCRIPTION
## Fix linter complaint by removing old import

I thought I had added this change to PR #3, but it must have slipped through. Removes a now unnecessary import.

Issue: Scottish-Natural-Heritage/Licensing#144