### PR TITLE
bugfix/copyright-attribution

### DIFF
--- a/src/views/meat-bait.njk
+++ b/src/views/meat-bait.njk
@@ -97,6 +97,7 @@
           },
           content: {
             html: '<img src="http://gateway.snh.gov.uk/go/?id=23" alt="A Larsen mate trap">' +
+              '<p class="govuk-body-s">&copy; The Game &amp; Wildlife Conservation Trust</p>' +
               '<p class="govuk-body">"Larsen mate trap" means a portable spring-operated cage-trap comprising two shell sections hinged along one edge connected by one or more springs and kept open by a split-rod/trip-perch (as manufactured by Elgeeco; or any trap which is equivalent to it in all relevant respects). When open (set) the minimum distance between any two corners of the trap must be 39 cm. The trap must not shut tightly along the majority of the length of the meeting edges.</p>'
           },
           expanded: false
@@ -107,6 +108,7 @@
           },
           content: {
             html: '<img src="http://gateway.snh.gov.uk/go/?id=24" alt="A Larsen pod trap">' +
+              '<p class="govuk-body-s">&copy; The Game &amp; Wildlife Conservation Trust</p>' +
               '<p class="govuk-body">"Larsen pod trap" means a portable spring or gravity operated cage-trap which has a single compartment with two side-mounted, spring activated trap-doors which can be set independently.</p>'
           },
           expanded: false

--- a/src/views/start.njk
+++ b/src/views/start.njk
@@ -70,6 +70,7 @@
           },
           content: {
             html: '<img src="http://gateway.snh.gov.uk/go/?id=22" alt="A Larsen trap">' +
+              '<p class="govuk-body-s">&copy; The Game &amp; Wildlife Conservation Trust</p>' +
               '<p class="govuk-body">"Larsen trap" means a portable cage-trap which has a closed compartment for confining a live bird as a decoy and one or more spring or gravity activated trap-doors which are either top or side mounted.</p>'
           },
           expanded: false
@@ -80,6 +81,7 @@
           },
           content: {
             html: '<img src="http://gateway.snh.gov.uk/go/?id=23" alt="A Larsen mate trap">' +
+              '<p class="govuk-body-s">&copy; The Game &amp; Wildlife Conservation Trust</p>' +
               '<p class="govuk-body">"Larsen mate trap" means a portable spring-operated cage-trap comprising two shell sections hinged along one edge connected by one or more springs and kept open by a split-rod/trip-perch (as manufactured by Elgeeco; or any trap which is equivalent to it in all relevant respects). When open (set) the minimum distance between any two corners of the trap must be 39 cm. The trap must not shut tightly along the majority of the length of the meeting edges.</p>'
           },
           expanded: false
@@ -90,6 +92,7 @@
           },
           content: {
             html: '<img src="http://gateway.snh.gov.uk/go/?id=24" alt="A Larsen pod trap">' +
+              '<p class="govuk-body-s">&copy; The Game &amp; Wildlife Conservation Trust</p>' +
               '<p class="govuk-body">"Larsen pod trap" means a portable spring or gravity operated cage-trap which has a single compartment with two side-mounted, spring activated trap-doors which can be set independently.</p>'
           },
           expanded: false
@@ -100,6 +103,7 @@
           },
           content: {
             html: '<img src="http://gateway.snh.gov.uk/go/?id=25" alt="A multi-catch cage trap">' +
+              '<p class="govuk-body-s">&copy; The Game &amp; Wildlife Conservation Trust</p>' +
               '<p class="govuk-body">"Multi-catch cage trap" means a cage large enough to be entered by the operator, which is covered in mesh and uses either a roof-funnel, ground-funnel or ladder/letterbox entry point for birds to gain access to the cage.</p>'
           },
           expanded: false


### PR DESCRIPTION
## Add the copyright attribution to the images

All of the trap images now have the copyright notice under them.

Issue: Scottish-Natural-Heritage/Licensing#156